### PR TITLE
build: add support for dynamic file names in all npm scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,9 @@
-const fs = require('fs');
-var nodemon = require('nodemon');
+const { fileName } = require('./scripts/filename');
+const nodemon = require('nodemon');
 
-const filename = process.argv[2];
+const path = fileName(process.argv[2]);
 
-let runFile = 'app';
-if (filename !== undefined) {
-  try {
-    if (fs.existsSync(`${__dirname}/src/${filename}.ts`)) {
-      runFile = filename;
-    }
-  } catch (error) {}
-}
-
-nodemon(`--quiet --config nodemon.json src/${runFile}.ts`);
+nodemon(`--quiet --config nodemon.json ${path}`);
 
 nodemon.on('start', () => {
   console.clear();

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "scripts": {
     "sandbox": "node index.js",
-    "vim": "vim -s scripts/vim-sandbox.vim src/app.ts",
-    "nvim": "nvim -s scripts/vim-sandbox.vim src/app.ts",
-    "copy:default": "cp templates/app.template.ts src/app.ts",
-    "copy:rxjs": "cp templates/rxjs.template.ts src/app.ts"
+    "vim": "node scripts/run-vim.js vim",
+    "nvim": "node scripts/run-vim.js nvim",
+    "copy:default": "node scripts/copy.js app",
+    "copy:rxjs": "node scripts/copy.js rxjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/copy.js
+++ b/scripts/copy.js
@@ -1,0 +1,6 @@
+const fs = require('fs');
+const { templateName, fileName } = require('./filename');
+const template = process.argv[2];
+const path = fileName(process.argv[3], false);
+
+fs.copyFileSync(`templates/${template}.template.ts`, path);

--- a/scripts/filename.js
+++ b/scripts/filename.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+
+function fileName(name, checkAvail = true) {
+  if (name !== undefined) {
+    const fileName = `src/${name}.ts`;
+    if (checkAvail === false) {
+      return fileName;
+    }
+    try {
+      if (fs.existsSync(`${__dirname}/../${fileName}`)) {
+        return fileName;
+      }
+    } catch (error) {}
+  }
+  return 'src/app.ts';
+}
+module.exports = { fileName };

--- a/scripts/run-vim.js
+++ b/scripts/run-vim.js
@@ -1,0 +1,9 @@
+const { fileName } = require('./filename');
+const editor = process.argv[2];
+const path = fileName(process.argv[3]);
+
+const child_process = require('child_process')
+
+child_process.spawn(editor, ['-s', 'scripts/vim-sandbox.vim', path], {
+  stdio: 'inherit'
+});

--- a/scripts/vim-sandbox.vim
+++ b/scripts/vim-sandbox.vim
@@ -1,2 +1,2 @@
-:vs|:term npm run sandbox
+:vs|:term npm run sandbox %:t:r
 :wincmd h


### PR DESCRIPTION
Add possibillity to give a name as argument to all the npm run scripts. If no name given the target of the script will be src/app.ts. Also the vim environment is started using the given file name.