### PR TITLE
feat: add interface option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 package-lock.json
 src/*.ts
+dist

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "nvim": "node scripts/run-vim.js nvim",
     "copy:default": "node scripts/copy.js app",
     "copy:rxjs": "node scripts/copy.js rxjs",
+    "copy:example": "node scripts/copy.js example",
     "build": "tsc"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "vim": "node scripts/run-vim.js vim",
     "nvim": "node scripts/run-vim.js nvim",
     "copy:default": "node scripts/copy.js app",
-    "copy:rxjs": "node scripts/copy.js rxjs"
+    "copy:rxjs": "node scripts/copy.js rxjs",
+    "build": "tsc"
   },
   "repository": {
     "type": "git",
@@ -28,6 +29,8 @@
     "typescript": "^4.2.2"
   },
   "devDependencies": {
-    "@types/node": "^14.14.31"
+    "@types/node": "^14.14.31",
+    "blessed": "^0.1.81",
+    "blessed-contrib": "^4.8.21"
   }
 }

--- a/scripts/interface.js
+++ b/scripts/interface.js
@@ -2,11 +2,14 @@ const blessed = require('blessed');
 const contrib = require('blessed-contrib');
 const util = require('util');
 
-function buildUi(extras = {}) {
+const DEFAULT_DATA = { actions: [], extras: {} };
+
+function buildUi(data = {}) {
   screen = blessed.screen({
     title: 'Offline Blitz',
   });
 
+  // Create grid
   grid = new contrib.grid({
     rows: 36,
     cols: 12,
@@ -28,26 +31,76 @@ function buildUi(extras = {}) {
         fg: "yellow"
       }
     },
-    commands: buildMenuCommands(extras)
+    commands: buildMenuCommands({
+      ...DEFAULT_DATA.extras,
+      ...data.extras
+    }),
   });
-  //
+
+  // Create list for actions
+  actionList = grid.set(0, 0, 15, 4, blessed.list, {
+    label: 'Actions',
+    parent: screen,
+    keys: true,
+    vi: true,
+    align: 'left',
+    selectedFg: 'white',
+    selectedBg: 'blue',
+    //interactive: false,
+    padding: { left: 1, right: 1 },
+    style: {
+      selected: {
+        fg: "black",
+        bg: "light-yellow"
+      },
+      item: {
+        fg: 'light-blue',
+      },
+    },
+    columnSpacing: 1,
+  });
+  
+  // Create exeuction triggered log
+  executionLog = grid.set(15, 0, 21, 4, contrib.log, {
+    label: 'Execution triggered',
+    parent: screen,
+    fg: 'green',
+    selectedBg: 'blue',
+    padding: { left: 1, right: 1 },
+  });
+  
+  actions = data.actions !== undefined ? data.actions : DEFAULT_DATA.actions;
+  actionList.setItems(actions.map(action => action.title));
+
   //grid.set(row, col, rowSpan, colSpan, obj, opts)
-  log = grid.set(0,0,35,12, contrib.log, {
+  log = grid.set(0,4,35,8, contrib.log, {
+    label: 'Logging output',
+    parent: screen,
     fg: 'green',
     selectedFg: 'green',
-    label: 'Server log',
   });
 
   
-  screen.render()
+  // focus list directly
+  actionList.focus();
+  screen.render();
 }
 
 function buildMenuCommands(extras = {}) {
   let defaultCmds = {
     ' Exit': {
       keys: ['Q-q', 'Q', 'q', 'C-c', 'escape'],
-      callback: () => process.exit(0)
-    }
+      callback: () => process.exit(0),
+    },
+    ' Action': {
+      keys: ['n', 'enter'],
+      callback: () => {
+        if (actions[actionList.selected] !== undefined) {
+          actions[actionList.selected].callback();
+          executionLog.log(`${actions[actionList.selected].title} was triggered`);
+        }
+      },
+    },
   };
   return {...defaultCmds, ...extras};
 }

--- a/scripts/interface.js
+++ b/scripts/interface.js
@@ -1,0 +1,63 @@
+const blessed = require('blessed');
+const contrib = require('blessed-contrib');
+const util = require('util');
+
+function buildUi(extras = {}) {
+  screen = blessed.screen({
+    title: 'Offline Blitz',
+  });
+
+  grid = new contrib.grid({
+    rows: 36,
+    cols: 12,
+    screen: screen,
+  });
+
+  // Create menu
+  menubar = blessed.listbar({
+    parent: screen,
+    keys: true,
+    bottom: 0,
+    left: 0,
+    height: 1,
+    style: {
+      item: {
+        fg: "yellow"
+      },
+      selected: {
+        fg: "yellow"
+      }
+    },
+    commands: buildMenuCommands(extras)
+  });
+  //
+  //grid.set(row, col, rowSpan, colSpan, obj, opts)
+  log = grid.set(0,0,35,12, contrib.log, {
+    fg: 'green',
+    selectedFg: 'green',
+    label: 'Server log',
+  });
+
+  
+  screen.render()
+}
+
+function buildMenuCommands(extras = {}) {
+  let defaultCmds = {
+    ' Exit': {
+      keys: ['Q-q', 'Q', 'q', 'C-c', 'escape'],
+      callback: () => process.exit(0)
+    }
+  };
+  return {...defaultCmds, ...extras};
+}
+
+number = 0;
+function logObject(object) {
+  log.log(`${number++}: ${util.inspect(object, false, null, true)}`);
+}
+
+module.exports = {
+  logObject,
+  buildUi,
+};

--- a/templates/example.template.ts
+++ b/templates/example.template.ts
@@ -1,0 +1,43 @@
+import { merge, NEVER, Subject, timer } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
+const { logObject, buildUi } = require('../scripts/interface');
+
+const extras = { 
+  ' Info': {
+    keys: ['i'],
+    callback: () => {
+      logObject(
+        'App.ts include a continous running stream of bananas with a trigger for labour on work and off work.'
+      );
+    }
+  },
+};
+const actions = [
+  { 
+    title: 'Throw in a banana on the band',
+    callback: () => {
+      manualBananas$.next();
+    },
+  },
+  { 
+    title: 'Start/Stop the banana band',
+    callback: () => {
+      bananaBandIsStopped = !bananaBandIsStopped;
+    },
+  },
+];
+buildUi({ actions, extras });
+
+const manualBananas$ = new Subject<void>();
+let numberOfBananas = 0;
+let bananaBandIsStopped = false;
+const frequency$ = timer(0, 3000);
+const runningBand$ = frequency$.pipe(
+  switchMap(() => bananaBandIsStopped ? NEVER : frequency$),
+);
+const bananas$ = merge(runningBand$, manualBananas$).pipe(
+  map(() => numberOfBananas++),
+);
+
+bananas$.subscribe(res => logObject(res));
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
     "noUnusedParameters": false,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
-  }
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist/"
+  },
+  "exclude": ["node_modules", "templates"]
 }


### PR DESCRIPTION
# PoC Terminal Interface

---
### UPDATE
Can be tested with `npm run copy:example` and `node dist/app.js`

---

Concept of interactive terminal interface. Used blessed for rendering (https://github.com/chjj/blessed). Its inspired by ncursor. This can be a improved a lot, all inputs appreciated.

The workflow right now => interfaces.js exports `buildUi` and `logObject` where buildUi NEEDS to be exectued if logObject is called since logObject refers to log (UI block object). ~`buildUi(extras = {})`~ `buildUi(data = {}) is exposed so an user can be pass actions to perform or extra keylisteners. Example of usage can be found below.

### Steps:
1. Integrate `buildUi` and `logObject` in x.ts (~example found below~, look at example.template instead)
2. run `npm run build` to compile
3. `node dist/x.js`

### Limitations:
* nodemon interfers with buffer so "cant" be used effienctly with blessed (it works but look quite weird and intercepts key listener)
* right now needs to compile manually with `npm run build` each time file is changed (this implies this should more be used when "testing" something that is finished more or less.

### Future todos:
* Improve code (can be cleaner)
* Clarify usage (improve/clean up methods and document)
* Look into nodemon configuration OR other solution for smoother dev experience

### References:
* https://github.com/chjj/blessed
* https://github.com/yaronn/blessed-contrib

### Screenshot
![image](https://user-images.githubusercontent.com/28264731/109427343-46b14000-79f2-11eb-94cc-228b24ff66f8.png)

### Example app.ts:
(look at example.template instead)
```javascript
// === rxjs.template.ts =============
console.clear(); // clear console for each save
import { of, Subject } from 'rxjs';
import { map, filter } from 'rxjs/operators';
// === end template =================
const { logObject, buildUi } = require('../scripts/interface');

const extras = { 
  ' Next': {
    keys: ['n'],
    callback: () => {
      const test = {
        test: true,
        type: 'child',
      };
      stream.next(test);
    }
  },
};
buildUi(extras);

const stream = new Subject<any>();

const stream$ = stream.asObservable();

stream$.subscribe(res => logObject(res));
```

